### PR TITLE
Feat: 2.0.0 - Export to proper MDX and fix issues, should work with Nextra native

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ A CLI tool to export Notion database pages to MDX files with frontmatter metadat
 - Maintains Notion content structure using notion-to-md
 - Generates clean filenames from page titles
 - Includes creation and last edited timestamps
+- Supports internal link transformations
+- Optional JSON export for raw data
 
 ## Prerequisites
 
@@ -44,19 +46,52 @@ export NOTION_TOKEN=your_integration_token
 
 ## Usage
 
-### Export Command
+### Export to MDX
 
 ```bash
-notion_mdx export -d <database_id> -o <output_path>
+notion_mdx export-mdx --id <database_id> -o <output_path> [options]
 ```
 
 Options:
-- `-d, --database`: Required. The Notion database ID
+- `--id`: Required. The Notion database ID
 - `-o, --output`: Required. The output directory path for MDX files
+- `--include-json`: Optional. Include raw JSON export in output directory
+- `--base-path`: Optional. Base path for internal links (e.g., /docs)
+- `--no-frontmatter`: Optional. Exclude frontmatter from MDX files
 
 Example:
 ```bash
-notion_mdx export -d "123456789abcdef" -o "./content/posts"
+notion_mdx export-mdx --id "123456789abcdef" -o "./content/posts" --base-path "/docs"
+```
+
+### Export to JSON
+
+```bash
+notion_mdx json --id <database_id> -o <output_path>
+```
+
+Options:
+- `--id`: Required. The Notion database ID
+- `-o, --output`: Required. The output directory path for JSON file
+
+Example:
+```bash
+notion_mdx json --id "123456789abcdef" -o "./content/data"
+```
+
+### Export Raw JSON
+
+```bash
+notion_mdx raw-json --id <id> [-o <output_path>]
+```
+
+Options:
+- `--id`: Required. The Notion database or page ID
+- `-o, --output`: Optional. Output file path (defaults to stdout)
+
+Example:
+```bash
+notion_mdx raw-json --id "123456789abcdef" -o "./data/raw.json"
 ```
 
 ### Finding Your Database ID
@@ -78,6 +113,7 @@ title: Page Title
 notionId: page-id
 createdAt: 2024-01-01T00:00:00.000Z
 lastEditedAt: 2024-01-01T00:00:00.000Z
+weight: 0
 ---
 
 [Your page content here]
@@ -91,7 +127,7 @@ To develop locally:
 2. Install dependencies: `npm install`
 3. Set up your NOTION_TOKEN environment variable
 4. Link the package locally: `npm link`
-5. Run the CLI: `notion_mdx export -d <database_id> -o <output_path>`
+5. Run the CLI: `notion_mdx export-mdx --id <database_id> -o <output_path>`
 
 ### Testing and Linting
 

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ A CLI tool to export Notion database pages to MDX files with frontmatter metadat
 You can install this CLI tool globally using npm:
 
 ```bash
-npm install -g @1984vc/notion_mdx
+npm install -g @1984vc/notion_mdx@2.0.0
 ```
 
 Or locally in your project:
 
 ```bash
-npm add -D @1984vc/notion_mdx
+npm add -D @1984vc/notion_mdx@2.0.0
 ```
 
 ## Setup
@@ -142,6 +142,13 @@ The release workflow will automatically:
 - Publish to npm under the @1984vc organization
 
 Note: Publishing requires an NPM_TOKEN secret to be set in the repository's GitHub secrets.
+
+## Dependencies
+
+Key dependencies:
+- @notionhq/client: ^2.2.15
+- commander: ^12.1.0
+- notion-to-md: ^3.1.1
 
 ## Error Handling
 

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -4,7 +4,9 @@ import { Command } from 'commander';
 import { readFile } from 'fs/promises';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { NotionExporter } from './notion.js';
+import { NotionMarkdownExporter } from './markdown.js';
+import { NotionJsonExporter } from './json.js';
+import { NotionRawExporter } from './raw-json.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -22,18 +24,18 @@ async function main(): Promise<void> {
 
   program
     .name('notion_mdx')
-    .description('Export Notion database pages to MDX files')
+    .description('Export Notion database pages to various formats')
     .version(packageJson.version);
 
   interface ExportOptions {
-    database: string;
+    id: string;
     output: string;
   }
 
   program
-    .command('export')
+    .command('export-markdown')
     .description('Export pages from a Notion database to MDX files')
-    .requiredOption('-d, --database <id>', 'Notion database ID')
+    .requiredOption('--id <id>', 'Notion database ID')
     .requiredOption('-o, --output <path>', 'Output directory path')
     .action(async (options: ExportOptions) => {
       if (!NOTION_TOKEN) {
@@ -43,9 +45,9 @@ async function main(): Promise<void> {
       }
 
       try {
-        const exporter = new NotionExporter(NOTION_TOKEN);
+        const exporter = new NotionMarkdownExporter(NOTION_TOKEN);
         const progress = await exporter.exportDatabase({
-          database: options.database,
+          database: options.id,
           output: options.output,
           notionToken: NOTION_TOKEN
         });
@@ -67,6 +69,81 @@ async function main(): Promise<void> {
               console.log('\n✨ Export complete!');
               break;
           }
+        }
+      } catch (error) {
+        console.error('❌ Export failed:', error instanceof Error ? error.message : String(error));
+        process.exit(1);
+      }
+    });
+
+  program
+    .command('json')
+    .description('Export pages from a Notion database to a JSON file')
+    .requiredOption('--id <id>', 'Notion database ID')
+    .requiredOption('-o, --output <path>', 'Output directory path')
+    .action(async (options: ExportOptions) => {
+      if (!NOTION_TOKEN) {
+        console.error('Error: NOTION_TOKEN environment variable is required');
+        console.error('Please set it with: export NOTION_TOKEN=your_integration_token');
+        process.exit(1);
+      }
+
+      try {
+        const exporter = new NotionJsonExporter(NOTION_TOKEN);
+        const progress = await exporter.exportDatabase({
+          database: options.id,
+          output: options.output,
+          notionToken: NOTION_TOKEN
+        });
+
+        // Handle progress updates
+        for (const update of progress) {
+          switch (update.type) {
+            case 'start':
+              console.log(`🔍 Found ${update.totalPages} pages to export`);
+              break;
+            case 'page':
+              if (update.error) {
+                console.error(`❌ [${update.currentPage}/${update.totalPages}] Error processing page ${update.pageId}: ${update.error}`);
+              } else {
+                console.log(`✅ [${update.currentPage}/${update.totalPages}] Updated: ${update.outputPath}`);
+              }
+              break;
+            case 'complete':
+              console.log('\n✨ Export complete!');
+              break;
+          }
+        }
+      } catch (error) {
+        console.error('❌ Export failed:', error instanceof Error ? error.message : String(error));
+        process.exit(1);
+      }
+    });
+
+  program
+    .command('raw-json')
+    .description('Export raw JSON response from Notion API for a database or page')
+    .requiredOption('--id <id>', 'Notion database or page ID')
+    .option('-o, --output <path>', 'Output file path (optional, defaults to stdout)')
+    .action(async (options: { id: string, output?: string }) => {
+      if (!NOTION_TOKEN) {
+        console.error('Error: NOTION_TOKEN environment variable is required');
+        console.error('Please set it with: export NOTION_TOKEN=your_integration_token');
+        process.exit(1);
+      }
+
+      try {
+        const exporter = new NotionRawExporter(NOTION_TOKEN);
+        const json = await exporter.exportRaw({
+          id: options.id,
+          output: options.output,
+          notionToken: NOTION_TOKEN
+        });
+
+        if (!options.output) {
+          console.log(json);
+        } else {
+          console.log(`✅ Raw JSON exported to: ${options.output}`);
         }
       } catch (error) {
         console.error('❌ Export failed:', error instanceof Error ? error.message : String(error));

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -31,6 +31,7 @@ async function main(): Promise<void> {
     id: string;
     output: string;
     includeJson?: boolean;
+    basePath?: string;
   }
 
   program
@@ -39,6 +40,7 @@ async function main(): Promise<void> {
     .requiredOption('--id <id>', 'Notion database ID')
     .requiredOption('-o, --output <path>', 'Output directory path')
     .option('--include-json', 'Include raw JSON export in output directory')
+    .option('--base-path <path>', 'Base path for internal links (e.g., /docs)')
     .action(async (options: ExportOptions) => {
       if (!NOTION_TOKEN) {
         console.error('Error: NOTION_TOKEN environment variable is required');
@@ -52,7 +54,8 @@ async function main(): Promise<void> {
           database: options.id,
           output: options.output,
           notionToken: NOTION_TOKEN,
-          includeJson: options.includeJson
+          includeJson: options.includeJson,
+          basePath: options.basePath
         });
 
         // Handle progress updates

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -30,13 +30,15 @@ async function main(): Promise<void> {
   interface ExportOptions {
     id: string;
     output: string;
+    includeJson?: boolean;
   }
 
   program
-    .command('export-markdown')
+    .command('export-mdx')
     .description('Export pages from a Notion database to MDX files')
     .requiredOption('--id <id>', 'Notion database ID')
     .requiredOption('-o, --output <path>', 'Output directory path')
+    .option('--include-json', 'Include raw JSON export in output directory')
     .action(async (options: ExportOptions) => {
       if (!NOTION_TOKEN) {
         console.error('Error: NOTION_TOKEN environment variable is required');
@@ -49,7 +51,8 @@ async function main(): Promise<void> {
         const progress = await exporter.exportDatabase({
           database: options.id,
           output: options.output,
-          notionToken: NOTION_TOKEN
+          notionToken: NOTION_TOKEN,
+          includeJson: options.includeJson
         });
 
         // Handle progress updates
@@ -66,6 +69,9 @@ async function main(): Promise<void> {
               }
               break;
             case 'complete':
+              if (options.includeJson) {
+                console.log('📄 Generated index.json with raw database content');
+              }
               console.log('\n✨ Export complete!');
               break;
           }

--- a/bin/json.ts
+++ b/bin/json.ts
@@ -1,0 +1,120 @@
+import { Client, isFullPage } from '@notionhq/client';
+import { mkdir, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { PageObjectResponse } from '@notionhq/client/build/src/api-endpoints.js';
+
+interface ExportOptions {
+  database: string;
+  output: string;
+  notionToken: string;
+}
+
+interface ExportProgress {
+  type: 'start' | 'page' | 'complete';
+  totalPages?: number;
+  currentPage?: number;
+  pageId?: string;
+  outputPath?: string;
+  error?: string;
+}
+
+interface TitleProperty {
+  type: 'title';
+  title: Array<{
+    plain_text: string;
+  }>;
+}
+
+interface RichTextProperty {
+  type: 'rich_text';
+  rich_text: Array<{
+    plain_text: string;
+  }>;
+}
+
+type NotionProperty = TitleProperty | RichTextProperty;
+
+export class NotionJsonExporter {
+  private notion: Client;
+
+  constructor(notionToken: string) {
+    this.notion = new Client({ auth: notionToken });
+  }
+
+  private async getPageTitle(pageInfo: PageObjectResponse): Promise<string> {
+    const properties = pageInfo.properties as Record<string, NotionProperty>;
+    const titleProp = Object.values(properties).find(
+      (prop): prop is TitleProperty => prop.type === 'title'
+    );
+
+    return titleProp?.title?.[0]?.plain_text || 'untitled';
+  }
+
+  private async processPage(page: PageObjectResponse, index: number): Promise<Record<string, any>> {
+    const pageInfo = await this.notion.pages.retrieve({ page_id: page.id });
+    
+    if (!isFullPage(pageInfo)) {
+      throw new Error('Retrieved incomplete page object');
+    }
+
+    const title = await this.getPageTitle(pageInfo);
+    const blocks = await this.notion.blocks.children.list({ block_id: page.id });
+
+    return {
+      id: page.id,
+      title,
+      created_time: pageInfo.created_time,
+      last_edited_time: pageInfo.last_edited_time,
+      sort_order: index,
+      properties: pageInfo.properties,
+      blocks: blocks.results
+    };
+  }
+
+  public async exportDatabase({ database, output }: ExportOptions): Promise<ExportProgress[]> {
+    const progress: ExportProgress[] = [];
+    
+    await mkdir(output, { recursive: true });
+
+    const response = await this.notion.databases.query({
+      database_id: database
+    });
+
+    progress.push({ 
+      type: 'start',
+      totalPages: response.results.length 
+    });
+
+    const pages = [];
+
+    for (const [index, page] of response.results.entries()) {
+      try {
+        const exportedPage = await this.processPage(page as PageObjectResponse, index);
+        pages.push(exportedPage);
+
+        const outputPath = join(output, 'notion-export.json');
+        await writeFile(outputPath, JSON.stringify({ pages }, null, 2), 'utf8');
+        
+        progress.push({
+          type: 'page',
+          currentPage: index + 1,
+          totalPages: response.results.length,
+          pageId: page.id,
+          outputPath
+        });
+
+      } catch (error) {
+        progress.push({
+          type: 'page',
+          currentPage: index + 1,
+          totalPages: response.results.length,
+          pageId: page.id,
+          error: error instanceof Error ? error.message : String(error)
+        });
+      }
+    }
+
+    progress.push({ type: 'complete' });
+    return progress;
+  }
+}

--- a/bin/json.ts
+++ b/bin/json.ts
@@ -65,7 +65,7 @@ export class NotionJsonExporter {
       title,
       created_time: pageInfo.created_time,
       last_edited_time: pageInfo.last_edited_time,
-      sort_order: index,
+      weight: index,
       properties: pageInfo.properties,
       blocks: blocks.results
     };

--- a/bin/markdown.ts
+++ b/bin/markdown.ts
@@ -47,7 +47,7 @@ interface RichTextProperty {
 
 type NotionProperty = TitleProperty | RichTextProperty;
 
-export class NotionExporter {
+export class NotionMarkdownExporter {
   private notion: Client;
   private n2m: NotionToMarkdown;
   private pagePathCache: Map<string, string>;
@@ -85,10 +85,8 @@ export class NotionExporter {
 
   private async getPagePath(pageId: string): Promise<string | null> {
     try {
-      // Format the ID with hyphens if it doesn't have them
       const formattedId = pageId.replace(/(.{8})(.{4})(.{4})(.{4})(.{12})/, '$1-$2-$3-$4-$5');
       
-      // Check cache first
       if (this.pagePathCache.has(formattedId)) {
         return this.pagePathCache.get(formattedId) || null;
       }
@@ -107,7 +105,6 @@ export class NotionExporter {
         return path;
       }
 
-      // If no path property, cache null to avoid repeated lookups
       this.pagePathCache.set(formattedId, '');
       return null;
     } catch (error) {
@@ -117,7 +114,6 @@ export class NotionExporter {
   }
 
   private async transformDatabaseLinks(markdown: string): Promise<string> {
-    // Match Markdown links with Notion page IDs
     const linkRegex = /\[([^\]]+)\]\(\/([a-f0-9]{32})\)/g;
     let transformedMarkdown = markdown;
 
@@ -167,7 +163,6 @@ export class NotionExporter {
   public async exportDatabase({ database, output }: ExportOptions): Promise<ExportProgress[]> {
     const progress: ExportProgress[] = [];
     
-    // Create output directory if it doesn't exist
     await mkdir(output, { recursive: true });
 
     const response = await this.notion.databases.query({
@@ -183,11 +178,9 @@ export class NotionExporter {
       try {
         const exportedPage = await this.processPage(page as PageObjectResponse, output, index);
 
-        // Create necessary directories
         const dirPath = dirname(exportedPage.outputPath);
         await mkdir(dirPath, { recursive: true });
 
-        // Add frontmatter and write to file
         const content = `---
 title: ${exportedPage.title}
 notionId: ${exportedPage.metadata.notionId}

--- a/bin/markdown.ts
+++ b/bin/markdown.ts
@@ -104,7 +104,9 @@ export class NotionMarkdownExporter {
 
   private async getPagePath(pageId: string): Promise<string | null> {
     try {
-      const formattedId = pageId.replace(/(.{8})(.{4})(.{4})(.{4})(.{12})/, '$1-$2-$3-$4-$5');
+      // Remove any existing hyphens and format the ID
+      const cleanId = pageId.replace(/-/g, '');
+      const formattedId = cleanId.replace(/(.{8})(.{4})(.{4})(.{4})(.{12})/, '$1-$2-$3-$4-$5');
       
       if (this.pagePathCache.has(formattedId)) {
         return this.pagePathCache.get(formattedId) || null;
@@ -133,7 +135,7 @@ export class NotionMarkdownExporter {
   }
 
   private async transformDatabaseLinks(markdown: string): Promise<string> {
-    const linkRegex = /\[([^\]]+)\]\(\/([a-f0-9]{32})\)/g;
+    const linkRegex = /\[([^\]]+)\]\(\/([a-f0-9-]{32,36})\)/g;
     let transformedMarkdown = markdown;
 
     for (const match of transformedMarkdown.matchAll(linkRegex)) {

--- a/bin/markdown.ts
+++ b/bin/markdown.ts
@@ -85,13 +85,11 @@ export class NotionMarkdownExporter {
 
   private async getPagePath(pageId: string): Promise<string | null> {
     try {
-      const formattedId = pageId.replace(/(.{8})(.{4})(.{4})(.{4})(.{12})/, '$1-$2-$3-$4-$5');
-      
-      if (this.pagePathCache.has(formattedId)) {
-        return this.pagePathCache.get(formattedId) || null;
+      if (this.pagePathCache.has(pageId)) {
+        return this.pagePathCache.get(pageId) || null;
       }
 
-      const pageInfo = await this.notion.pages.retrieve({ page_id: formattedId });
+      const pageInfo = await this.notion.pages.retrieve({ page_id: pageId });
       if (!isFullPage(pageInfo)) {
         return null;
       }
@@ -101,11 +99,11 @@ export class NotionMarkdownExporter {
       
       if (pathProp?.type === 'rich_text' && pathProp.rich_text[0]?.plain_text) {
         const path = pathProp.rich_text[0].plain_text;
-        this.pagePathCache.set(formattedId, path);
+        this.pagePathCache.set(pageId, path);
         return path;
       }
 
-      this.pagePathCache.set(formattedId, '');
+      this.pagePathCache.set(pageId, '');
       return null;
     } catch (error) {
       console.error(`Failed to fetch path for page ${pageId}:`, error);

--- a/bin/meta.ts
+++ b/bin/meta.ts
@@ -4,7 +4,7 @@ import { join, basename, dirname } from 'path';
 interface PageMeta {
   path: string;
   title: string;
-   weight: number;
+  weight: number;
 }
 
 export class MetaGenerator {
@@ -14,12 +14,12 @@ export class MetaGenerator {
     this.directoryPages = new Map();
   }
 
-  addPage(pagePath: string, title: string,  weight: number) {
+  addPage(pagePath: string, title: string, weight: number): void {
     const dir = dirname(pagePath);
     const pageInfo: PageMeta = {
       path: pagePath,
       title,
-       weight
+      weight
     };
 
     if (!this.directoryPages.has(dir)) {
@@ -33,8 +33,8 @@ export class MetaGenerator {
   }
 
   private generateMetaContent(pages: PageMeta[]): string {
-    // Sort pages by  weight
-    const sortedPages = [...pages].sort((a, b) => a. weight - b. weight);
+    // Sort pages by weight
+    const sortedPages = [...pages].sort((a, b) => a.weight - b.weight);
     
     const entries = sortedPages.map(page => {
       // Get filename without extension

--- a/bin/meta.ts
+++ b/bin/meta.ts
@@ -1,0 +1,54 @@
+import { writeFile, mkdir } from 'fs/promises';
+import { join, basename, dirname } from 'path';
+
+interface PageMeta {
+  path: string;
+  title: string;
+}
+
+export class MetaGenerator {
+  private directoryPages: Map<string, PageMeta[]>;
+
+  constructor() {
+    this.directoryPages = new Map();
+  }
+
+  addPage(pagePath: string, title: string) {
+    const dir = dirname(pagePath);
+    const pageInfo: PageMeta = {
+      path: pagePath,
+      title
+    };
+
+    if (!this.directoryPages.has(dir)) {
+      this.directoryPages.set(dir, []);
+    }
+    this.directoryPages.get(dir)?.push(pageInfo);
+  }
+
+  private generateMetaContent(pages: PageMeta[]): string {
+    const entries = pages.map(page => {
+      // Get filename without extension
+      const key = basename(page.path, '.mdx');
+      // Escape any quotes in the title
+      const title = page.title.replace(/'/g, "\\'");
+      return `  '${key}': '${title}'`;
+    });
+
+    return `export default {
+${entries.join(',\n')}
+}
+`;
+  }
+
+  async generateMetaFiles(): Promise<void> {
+    for (const [dir, pages] of this.directoryPages.entries()) {
+      // Create directory if it doesn't exist
+      await mkdir(dir, { recursive: true });
+      
+      const metaPath = join(dir, '_meta.ts');
+      const content = this.generateMetaContent(pages);
+      await writeFile(metaPath, content, 'utf8');
+    }
+  }
+}

--- a/bin/raw-json.ts
+++ b/bin/raw-json.ts
@@ -1,0 +1,60 @@
+import { Client } from '@notionhq/client';
+import { writeFile } from 'fs/promises';
+
+interface RawExportOptions {
+  id: string;
+  output?: string;
+  notionToken: string;
+}
+
+export class NotionRawExporter {
+  private notion: Client;
+
+  constructor(notionToken: string) {
+    this.notion = new Client({ auth: notionToken });
+  }
+
+  private async fetchDatabase(id: string): Promise<any> {
+    const response = await this.notion.databases.query({
+      database_id: id
+    });
+    return response;
+  }
+
+  private async fetchPage(id: string): Promise<any> {
+    const page = await this.notion.pages.retrieve({
+      page_id: id
+    });
+    const blocks = await this.notion.blocks.children.list({
+      block_id: id
+    });
+    return { page, blocks };
+  }
+
+  public async exportRaw({ id, output }: RawExportOptions): Promise<string> {
+    try {
+      // Try as database first
+      try {
+        const data = await this.fetchDatabase(id);
+        const json = JSON.stringify(data, null, 2);
+        if (output) {
+          await writeFile(output, json, 'utf8');
+        }
+        return json;
+      } catch (error) {
+        // If database fetch fails, try as page
+        if ((error as any)?.code === 'object_not_found' || (error as any)?.status === 404) {
+          const data = await this.fetchPage(id);
+          const json = JSON.stringify(data, null, 2);
+          if (output) {
+            await writeFile(output, json, 'utf8');
+          }
+          return json;
+        }
+        throw error;
+      }
+    } catch (error) {
+      throw new Error(`Failed to fetch Notion content: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1984vc/notion_mdx",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "CLI tool to export Notion database pages to MDX files with frontmatter",
   "homepage": "https://github.com/1984vc/notion_mdx",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@1984vc/notion_mdx",
   "version": "1.0.0",
   "description": "CLI tool to export Notion database pages to MDX files with frontmatter",
+  "homepage": "https://github.com/1984vc/notion_mdx",
   "main": "dist/index.js",
   "bin": {
     "notion_mdx": "./dist/index.js"

--- a/test/json.test.ts
+++ b/test/json.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { NotionJsonExporter } from '../bin/json';
-import type { PageObjectResponse } from '@notionhq/client/build/src/api-endpoints';
+import type { PageObjectResponse, ListBlockChildrenResponse } from '@notionhq/client/build/src/api-endpoints';
 
 describe('NotionJsonExporter', () => {
   let exporter: NotionJsonExporter;
 
-  const createMockPage = (properties: any): PageObjectResponse => ({
+  const createMockPage = (properties: Record<string, unknown>): PageObjectResponse => ({
     object: 'page',
     id: 'test-id',
     created_time: '2023-01-01T00:00:00.000Z',
@@ -34,7 +34,7 @@ describe('NotionJsonExporter', () => {
   });
 
   describe('getPageTitle', () => {
-    it('should extract title from page properties', async () => {
+    it('should extract title from page properties', async (): Promise<void> => {
       const mockPage = createMockPage({
         Name: {
           type: 'title',
@@ -61,7 +61,7 @@ describe('NotionJsonExporter', () => {
       expect(title).toBe('Test Page');
     });
 
-    it('should return "untitled" when no title is found', async () => {
+    it('should return "untitled" when no title is found', async (): Promise<void> => {
       const mockPage = createMockPage({});
 
       // @ts-expect-error accessing private method for testing
@@ -71,7 +71,7 @@ describe('NotionJsonExporter', () => {
   });
 
   describe('processPage', () => {
-    it('should process page with all required fields', async () => {
+    it('should process page with all required fields', async (): Promise<void> => {
       const mockPage = createMockPage({
         Name: {
           type: 'title',
@@ -95,15 +95,43 @@ describe('NotionJsonExporter', () => {
 
       // Mock the necessary methods
       // @ts-expect-error accessing private instance for testing
-      exporter.notion.pages.retrieve = async () => mockPage;
+      exporter.notion.pages.retrieve = async (): Promise<PageObjectResponse> => mockPage;
       // @ts-expect-error accessing private instance for testing
-      exporter.notion.blocks.children.list = async () => ({
+      exporter.notion.blocks.children.list = async (): Promise<ListBlockChildrenResponse> => ({
+        object: 'list',
         results: [
           {
+            object: 'block',
+            id: 'block-id',
+            parent: { type: 'page_id', page_id: 'page-id' },
+            created_time: '2024-01-01T00:00:00.000Z',
+            last_edited_time: '2024-01-01T00:00:00.000Z',
+            created_by: { object: 'user', id: 'user-id' },
+            last_edited_by: { object: 'user', id: 'user-id' },
+            has_children: false,
+            archived: false,
             type: 'paragraph',
-            paragraph: { text: [{ plain_text: 'Test content' }] }
+            paragraph: {
+              rich_text: [{
+                type: 'text',
+                text: { content: 'Test content', link: null },
+                annotations: {
+                  bold: false,
+                  italic: false,
+                  strikethrough: false,
+                  underline: false,
+                  code: false,
+                  color: 'default'
+                },
+                plain_text: 'Test content',
+                href: null
+              }],
+              color: 'default'
+            }
           }
-        ]
+        ],
+        next_cursor: null,
+        has_more: false
       });
 
       // @ts-expect-error accessing private method for testing

--- a/test/json.test.ts
+++ b/test/json.test.ts
@@ -111,7 +111,7 @@ describe('NotionJsonExporter', () => {
 
       expect(result.id).toBe('test-id');
       expect(result.title).toBe('Test Page');
-      expect(result.sort_order).toBe(5);
+      expect(result.weight).toBe(5);
       expect(result.created_time).toBe('2023-01-01T00:00:00.000Z');
       expect(result.last_edited_time).toBe('2023-01-02T00:00:00.000Z');
       expect(result.properties).toBeDefined();

--- a/test/json.test.ts
+++ b/test/json.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { NotionJsonExporter } from '../bin/json';
+import type { PageObjectResponse } from '@notionhq/client/build/src/api-endpoints';
+
+describe('NotionJsonExporter', () => {
+  let exporter: NotionJsonExporter;
+
+  const createMockPage = (properties: any): PageObjectResponse => ({
+    object: 'page',
+    id: 'test-id',
+    created_time: '2023-01-01T00:00:00.000Z',
+    last_edited_time: '2023-01-02T00:00:00.000Z',
+    created_by: {
+      object: 'user',
+      id: 'user-id'
+    },
+    last_edited_by: {
+      object: 'user',
+      id: 'user-id'
+    },
+    cover: null,
+    icon: null,
+    parent: {
+      type: 'database_id',
+      database_id: 'database-id'
+    },
+    archived: false,
+    properties,
+    url: 'https://notion.so/test-page'
+  } as PageObjectResponse);
+
+  beforeEach(() => {
+    exporter = new NotionJsonExporter('fake-token');
+  });
+
+  describe('getPageTitle', () => {
+    it('should extract title from page properties', async () => {
+      const mockPage = createMockPage({
+        Name: {
+          type: 'title',
+          title: [
+            {
+              type: 'text',
+              text: { content: 'Test Page' },
+              plain_text: 'Test Page',
+              annotations: {
+                bold: false,
+                italic: false,
+                strikethrough: false,
+                underline: false,
+                code: false,
+                color: 'default'
+              }
+            }
+          ]
+        }
+      });
+
+      // @ts-expect-error accessing private method for testing
+      const title = await exporter.getPageTitle(mockPage);
+      expect(title).toBe('Test Page');
+    });
+
+    it('should return "untitled" when no title is found', async () => {
+      const mockPage = createMockPage({});
+
+      // @ts-expect-error accessing private method for testing
+      const title = await exporter.getPageTitle(mockPage);
+      expect(title).toBe('untitled');
+    });
+  });
+
+  describe('processPage', () => {
+    it('should process page with all required fields', async () => {
+      const mockPage = createMockPage({
+        Name: {
+          type: 'title',
+          title: [
+            {
+              type: 'text',
+              text: { content: 'Test Page' },
+              plain_text: 'Test Page',
+              annotations: {
+                bold: false,
+                italic: false,
+                strikethrough: false,
+                underline: false,
+                code: false,
+                color: 'default'
+              }
+            }
+          ]
+        }
+      });
+
+      // Mock the necessary methods
+      // @ts-expect-error accessing private instance for testing
+      exporter.notion.pages.retrieve = async () => mockPage;
+      // @ts-expect-error accessing private instance for testing
+      exporter.notion.blocks.children.list = async () => ({
+        results: [
+          {
+            type: 'paragraph',
+            paragraph: { text: [{ plain_text: 'Test content' }] }
+          }
+        ]
+      });
+
+      // @ts-expect-error accessing private method for testing
+      const result = await exporter.processPage(mockPage, 5);
+
+      expect(result.id).toBe('test-id');
+      expect(result.title).toBe('Test Page');
+      expect(result.sort_order).toBe(5);
+      expect(result.created_time).toBe('2023-01-01T00:00:00.000Z');
+      expect(result.last_edited_time).toBe('2023-01-02T00:00:00.000Z');
+      expect(result.properties).toBeDefined();
+      expect(result.blocks).toBeDefined();
+      expect(Array.isArray(result.blocks)).toBe(true);
+    });
+  });
+});

--- a/test/meta.test.ts
+++ b/test/meta.test.ts
@@ -18,11 +18,13 @@ describe('MetaGenerator', () => {
       // Add pages to the same directory
       generator.addPage(
         join(testDir, 'guides/cap-table-101.mdx'),
-        'Cap Table 101'
+        'Cap Table 101',
+        0
       );
       generator.addPage(
         join(testDir, 'guides/safe-vs-priced-rounds.mdx'),
-        'Safe vs Priced Rounds'
+        'Safe vs Priced Rounds',
+        1
       );
 
       await generator.generateMetaFiles();
@@ -39,11 +41,13 @@ describe('MetaGenerator', () => {
       // Add pages to different directories
       generator.addPage(
         join(testDir, 'guides/cap-table-101.mdx'),
-        'Cap Table 101'
+        'Cap Table 101',
+        0
       );
       generator.addPage(
         join(testDir, 'blog/first-post.mdx'),
-        'First Post'
+        'First Post',
+        0
       );
 
       await generator.generateMetaFiles();
@@ -64,7 +68,8 @@ describe('MetaGenerator', () => {
     it('should escape special characters in titles', async () => {
       generator.addPage(
         join(testDir, 'guides/special-page.mdx'),
-        "Title with 'quotes' and \"double quotes\""
+        "Title with 'quotes' and \"double quotes\"",
+        0
       );
 
       await generator.generateMetaFiles();
@@ -72,6 +77,35 @@ describe('MetaGenerator', () => {
       const metaContent = await readFile(join(testDir, 'guides/_meta.ts'), 'utf8');
       expect(metaContent).toBe(`export default {
   'special-page': 'Title with \\'quotes\\' and "double quotes"'
+}
+`);
+    });
+
+    it('should maintain order based on sort_order', async () => {
+      // Add pages in random order
+      generator.addPage(
+        join(testDir, 'guides/third.mdx'),
+        'Third Page',
+        2
+      );
+      generator.addPage(
+        join(testDir, 'guides/first.mdx'),
+        'First Page',
+        0
+      );
+      generator.addPage(
+        join(testDir, 'guides/second.mdx'),
+        'Second Page',
+        1
+      );
+
+      await generator.generateMetaFiles();
+
+      const metaContent = await readFile(join(testDir, 'guides/_meta.ts'), 'utf8');
+      expect(metaContent).toBe(`export default {
+  'first': 'First Page',
+  'second': 'Second Page',
+  'third': 'Third Page'
 }
 `);
     });

--- a/test/meta.test.ts
+++ b/test/meta.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MetaGenerator } from '../bin/meta';
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+describe('MetaGenerator', () => {
+  let generator: MetaGenerator;
+  let testDir: string;
+
+  beforeEach(() => {
+    generator = new MetaGenerator();
+    testDir = join(tmpdir(), 'notion-mdx-meta-test-' + Date.now());
+  });
+
+  describe('generateMetaFiles', () => {
+    it('should generate _meta.ts file with correct content', async () => {
+      // Add pages to the same directory
+      generator.addPage(
+        join(testDir, 'guides/cap-table-101.mdx'),
+        'Cap Table 101'
+      );
+      generator.addPage(
+        join(testDir, 'guides/safe-vs-priced-rounds.mdx'),
+        'Safe vs Priced Rounds'
+      );
+
+      await generator.generateMetaFiles();
+
+      const metaContent = await readFile(join(testDir, 'guides/_meta.ts'), 'utf8');
+      expect(metaContent).toBe(`export default {
+  'cap-table-101': 'Cap Table 101',
+  'safe-vs-priced-rounds': 'Safe vs Priced Rounds'
+}
+`);
+    });
+
+    it('should handle multiple directories', async () => {
+      // Add pages to different directories
+      generator.addPage(
+        join(testDir, 'guides/cap-table-101.mdx'),
+        'Cap Table 101'
+      );
+      generator.addPage(
+        join(testDir, 'blog/first-post.mdx'),
+        'First Post'
+      );
+
+      await generator.generateMetaFiles();
+
+      const guidesMetaContent = await readFile(join(testDir, 'guides/_meta.ts'), 'utf8');
+      expect(guidesMetaContent).toBe(`export default {
+  'cap-table-101': 'Cap Table 101'
+}
+`);
+
+      const blogMetaContent = await readFile(join(testDir, 'blog/_meta.ts'), 'utf8');
+      expect(blogMetaContent).toBe(`export default {
+  'first-post': 'First Post'
+}
+`);
+    });
+
+    it('should escape special characters in titles', async () => {
+      generator.addPage(
+        join(testDir, 'guides/special-page.mdx'),
+        "Title with 'quotes' and \"double quotes\""
+      );
+
+      await generator.generateMetaFiles();
+
+      const metaContent = await readFile(join(testDir, 'guides/_meta.ts'), 'utf8');
+      expect(metaContent).toBe(`export default {
+  'special-page': 'Title with \\'quotes\\' and "double quotes"'
+}
+`);
+    });
+  });
+});

--- a/test/notion.test.ts
+++ b/test/notion.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { NotionExporter } from '../bin/notion';
+import { NotionMarkdownExporter } from '../bin/markdown';
 import type { PageObjectResponse } from '@notionhq/client/build/src/api-endpoints';
 
-describe('NotionExporter', () => {
-  let exporter: NotionExporter;
+describe('NotionMarkdownExporter', () => {
+  let exporter: NotionMarkdownExporter;
 
   const createMockPage = (properties: any): PageObjectResponse => ({
     object: 'page',
@@ -30,7 +30,7 @@ describe('NotionExporter', () => {
   } as PageObjectResponse);
 
   beforeEach(() => {
-    exporter = new NotionExporter('fake-token');
+    exporter = new NotionMarkdownExporter('fake-token');
   });
 
   describe('getPageTitle', () => {

--- a/test/notion.test.ts
+++ b/test/notion.test.ts
@@ -5,34 +5,56 @@ import type { PageObjectResponse } from '@notionhq/client/build/src/api-endpoint
 describe('NotionExporter', () => {
   let exporter: NotionExporter;
 
+  const createMockPage = (properties: any): PageObjectResponse => ({
+    object: 'page',
+    id: 'test-id',
+    created_time: '2023-01-01T00:00:00.000Z',
+    last_edited_time: '2023-01-02T00:00:00.000Z',
+    created_by: {
+      object: 'user',
+      id: 'user-id'
+    },
+    last_edited_by: {
+      object: 'user',
+      id: 'user-id'
+    },
+    cover: null,
+    icon: null,
+    parent: {
+      type: 'database_id',
+      database_id: 'database-id'
+    },
+    archived: false,
+    properties,
+    url: 'https://notion.so/test-page'
+  } as PageObjectResponse);
+
   beforeEach(() => {
     exporter = new NotionExporter('fake-token');
   });
 
   describe('getPageTitle', () => {
     it('should extract title from page properties', async () => {
-      const mockPage = {
-        properties: {
-          Name: {
-            type: 'title',
-            title: [
-              {
-                type: 'text',
-                text: { content: 'Test Page' },
-                plain_text: 'Test Page',
-                annotations: {
-                  bold: false,
-                  italic: false,
-                  strikethrough: false,
-                  underline: false,
-                  code: false,
-                  color: 'default'
-                }
+      const mockPage = createMockPage({
+        Name: {
+          type: 'title',
+          title: [
+            {
+              type: 'text',
+              text: { content: 'Test Page' },
+              plain_text: 'Test Page',
+              annotations: {
+                bold: false,
+                italic: false,
+                strikethrough: false,
+                underline: false,
+                code: false,
+                color: 'default'
               }
-            ]
-          }
+            }
+          ]
         }
-      } as unknown as PageObjectResponse;
+      });
 
       // @ts-expect-error accessing private method for testing
       const title = await exporter.getPageTitle(mockPage);
@@ -40,13 +62,111 @@ describe('NotionExporter', () => {
     });
 
     it('should return "untitled" when no title is found', async () => {
-      const mockPage = {
-        properties: {}
-      } as unknown as PageObjectResponse;
+      const mockPage = createMockPage({});
 
       // @ts-expect-error accessing private method for testing
       const title = await exporter.getPageTitle(mockPage);
       expect(title).toBe('untitled');
+    });
+  });
+
+  describe('transformDatabaseLinks', () => {
+    it('should transform database links to use page paths', async () => {
+      // Mock the Notion API call
+      // @ts-expect-error accessing private instance for testing
+      exporter.notion.pages.retrieve = async ({ page_id }) => createMockPage({
+        path: {
+          type: 'rich_text',
+          rich_text: [{ plain_text: 'guides/safe-vs-priced-rounds' }]
+        }
+      });
+
+      const markdown = 'Check out [Safe vs Priced Rounds](/3c5a0edb257449558cf968f5ded58812)';
+      
+      // @ts-expect-error accessing private method for testing
+      const transformed = await exporter.transformDatabaseLinks(markdown);
+      
+      expect(transformed).toBe('Check out [Safe vs Priced Rounds](/guides/safe-vs-priced-rounds)');
+    });
+
+    it('should handle multiple database links', async () => {
+      // Mock the Notion API call with different responses based on page ID
+      // @ts-expect-error accessing private instance for testing
+      exporter.notion.pages.retrieve = async ({ page_id }) => {
+        const paths = {
+          '3c5a0edb257449558cf968f5ded58812': 'guides/safe-vs-priced-rounds',
+          '23f1324e5ecc4d32af0e81e60a03cf18': 'guides/pre-money-vs-post-money'
+        };
+        const id = page_id.replace(/-/g, '');
+        return createMockPage({
+          path: {
+            type: 'rich_text',
+            rich_text: [{ plain_text: paths[id] }]
+          }
+        });
+      };
+
+      const markdown = `Check out [Safe vs Priced Rounds](/3c5a0edb257449558cf968f5ded58812)
+And [Pre vs Post Money](/23f1324e5ecc4d32af0e81e60a03cf18)`;
+      
+      // @ts-expect-error accessing private method for testing
+      const transformed = await exporter.transformDatabaseLinks(markdown);
+      
+      expect(transformed).toBe(`Check out [Safe vs Priced Rounds](/guides/safe-vs-priced-rounds)
+And [Pre vs Post Money](/guides/pre-money-vs-post-money)`);
+    });
+
+    it('should preserve links that do not have matching pages', async () => {
+      // Mock the Notion API call to return a page without a path property
+      // @ts-expect-error accessing private instance for testing
+      exporter.notion.pages.retrieve = async () => createMockPage({});
+
+      const markdown = 'Check out [Missing Page](/3c5a0edb257449558cf968f5ded58812)';
+      
+      // @ts-expect-error accessing private method for testing
+      const transformed = await exporter.transformDatabaseLinks(markdown);
+      
+      expect(transformed).toBe(markdown);
+    });
+  });
+
+  describe('processPage', () => {
+    it('should include sort_order in page metadata', async () => {
+      const mockPage = createMockPage({
+        Name: {
+          type: 'title',
+          title: [
+            {
+              type: 'text',
+              text: { content: 'Test Page' },
+              plain_text: 'Test Page',
+              annotations: {
+                bold: false,
+                italic: false,
+                strikethrough: false,
+                underline: false,
+                code: false,
+                color: 'default'
+              }
+            }
+          ]
+        }
+      });
+
+      // Mock the necessary methods
+      // @ts-expect-error accessing private instance for testing
+      exporter.notion.pages.retrieve = async () => mockPage;
+      // @ts-expect-error accessing private instance for testing
+      exporter.n2m.pageToMarkdown = async () => [];
+      // @ts-expect-error accessing private instance for testing
+      exporter.n2m.toMarkdownString = () => ({ parent: '# Test Content' });
+
+      // @ts-expect-error accessing private method for testing
+      const result = await exporter.processPage(mockPage, '/output', 5);
+
+      expect(result.metadata.sort_order).toBe(5);
+      expect(result.metadata.notionId).toBe('test-id');
+      expect(result.title).toBe('Test Page');
     });
   });
 });

--- a/test/raw-json.test.ts
+++ b/test/raw-json.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { NotionRawExporter } from '../bin/raw-json';
+
+describe('NotionRawExporter', () => {
+  let exporter: NotionRawExporter;
+
+  beforeEach(() => {
+    exporter = new NotionRawExporter('fake-token');
+  });
+
+  describe('exportRaw', () => {
+    it('should fetch and format database data', async () => {
+      const mockDatabaseResponse = {
+        results: [
+          {
+            id: 'page-id',
+            properties: {
+              title: { type: 'title', title: [{ plain_text: 'Test Page' }] }
+            }
+          }
+        ]
+      };
+
+      // @ts-expect-error accessing private instance for testing
+      exporter.notion.databases.query = async () => mockDatabaseResponse;
+
+      const result = await exporter.exportRaw({ id: 'test-db-id', notionToken: 'fake-token' });
+      const parsed = JSON.parse(result);
+
+      expect(parsed).toEqual(mockDatabaseResponse);
+    });
+
+    it('should fetch and format page data when database fetch fails', async () => {
+      const mockPageResponse = {
+        id: 'page-id',
+        properties: {
+          title: { type: 'title', title: [{ plain_text: 'Test Page' }] }
+        }
+      };
+
+      const mockBlocksResponse = {
+        results: [
+          {
+            type: 'paragraph',
+            paragraph: { text: [{ plain_text: 'Test content' }] }
+          }
+        ]
+      };
+
+      // @ts-expect-error accessing private instance for testing
+      exporter.notion.databases.query = async () => {
+        const error: any = new Error('Not found');
+        error.code = 'object_not_found';
+        throw error;
+      };
+
+      // @ts-expect-error accessing private instance for testing
+      exporter.notion.pages.retrieve = async () => mockPageResponse;
+      // @ts-expect-error accessing private instance for testing
+      exporter.notion.blocks.children.list = async () => mockBlocksResponse;
+
+      const result = await exporter.exportRaw({ id: 'test-page-id', notionToken: 'fake-token' });
+      const parsed = JSON.parse(result);
+
+      expect(parsed).toEqual({
+        page: mockPageResponse,
+        blocks: mockBlocksResponse
+      });
+    });
+
+    it('should throw error when neither database nor page is found', async () => {
+      // @ts-expect-error accessing private instance for testing
+      exporter.notion.databases.query = async () => {
+        throw new Error('Database not found');
+      };
+
+      // @ts-expect-error accessing private instance for testing
+      exporter.notion.pages.retrieve = async () => {
+        throw new Error('Page not found');
+      };
+
+      await expect(
+        exporter.exportRaw({ id: 'invalid-id', notionToken: 'fake-token' })
+      ).rejects.toThrow('Failed to fetch Notion content');
+    });
+  });
+});

--- a/test/raw-json.test.ts
+++ b/test/raw-json.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { NotionRawExporter } from '../bin/raw-json';
+import type { QueryDatabaseResponse, PageObjectResponse, ListBlockChildrenResponse } from '@notionhq/client/build/src/api-endpoints';
+
+interface NotionError extends Error {
+  code?: string;
+  status?: number;
+}
 
 describe('NotionRawExporter', () => {
   let exporter: NotionRawExporter;
@@ -9,20 +15,54 @@ describe('NotionRawExporter', () => {
   });
 
   describe('exportRaw', () => {
-    it('should fetch and format database data', async () => {
+    it('should fetch and format database data', async (): Promise<void> => {
       const mockDatabaseResponse = {
+        type: 'page_or_database',
+        page_or_database: {},
+        object: 'list',
         results: [
           {
+            object: 'page',
             id: 'page-id',
+            created_time: '2024-01-01T00:00:00.000Z',
+            last_edited_time: '2024-01-01T00:00:00.000Z',
+            created_by: { object: 'user', id: 'user-id' },
+            last_edited_by: { object: 'user', id: 'user-id' },
+            cover: null,
+            icon: null,
+            parent: { type: 'database_id', database_id: 'test-db' },
+            archived: false,
             properties: {
-              title: { type: 'title', title: [{ plain_text: 'Test Page' }] }
-            }
-          }
-        ]
-      };
+              'Page Title': {
+                id: 'title-id',
+                type: 'title',
+                title: [{
+                  type: 'text',
+                  text: { content: 'Test Page', link: null },
+                  annotations: {
+                    bold: false,
+                    italic: false,
+                    strikethrough: false,
+                    underline: false,
+                    code: false,
+                    color: 'default'
+                  },
+                  plain_text: 'Test Page',
+                  href: null
+                }]
+              }
+            },
+            url: 'https://notion.so/test-page',
+            public_url: null,
+            in_trash: false
+          } as PageObjectResponse
+        ],
+        next_cursor: null,
+        has_more: false
+      } as unknown as QueryDatabaseResponse;
 
       // @ts-expect-error accessing private instance for testing
-      exporter.notion.databases.query = async () => mockDatabaseResponse;
+      exporter.notion.databases.query = async (): Promise<QueryDatabaseResponse> => mockDatabaseResponse;
 
       const result = await exporter.exportRaw({ id: 'test-db-id', notionToken: 'fake-token' });
       const parsed = JSON.parse(result);
@@ -30,34 +70,91 @@ describe('NotionRawExporter', () => {
       expect(parsed).toEqual(mockDatabaseResponse);
     });
 
-    it('should fetch and format page data when database fetch fails', async () => {
+    it('should fetch and format page data when database fetch fails', async (): Promise<void> => {
       const mockPageResponse = {
+        object: 'page',
         id: 'page-id',
+        created_time: '2024-01-01T00:00:00.000Z',
+        last_edited_time: '2024-01-01T00:00:00.000Z',
+        created_by: { object: 'user', id: 'user-id' },
+        last_edited_by: { object: 'user', id: 'user-id' },
+        cover: null,
+        icon: null,
+        parent: { type: 'database_id', database_id: 'test-db' },
+        archived: false,
         properties: {
-          title: { type: 'title', title: [{ plain_text: 'Test Page' }] }
-        }
-      };
+          'Page Title': {
+            id: 'title-id',
+            type: 'title',
+            title: [{
+              type: 'text',
+              text: { content: 'Test Page', link: null },
+              annotations: {
+                bold: false,
+                italic: false,
+                strikethrough: false,
+                underline: false,
+                code: false,
+                color: 'default'
+              },
+              plain_text: 'Test Page',
+              href: null
+            }]
+          }
+        },
+        url: 'https://notion.so/test-page',
+        public_url: null,
+        in_trash: false
+      } as unknown as PageObjectResponse;
 
       const mockBlocksResponse = {
+        object: 'list',
         results: [
           {
+            object: 'block',
+            id: 'block-id',
+            parent: { type: 'page_id', page_id: 'page-id' },
+            created_time: '2024-01-01T00:00:00.000Z',
+            last_edited_time: '2024-01-01T00:00:00.000Z',
+            created_by: { object: 'user', id: 'user-id' },
+            last_edited_by: { object: 'user', id: 'user-id' },
+            has_children: false,
+            archived: false,
             type: 'paragraph',
-            paragraph: { text: [{ plain_text: 'Test content' }] }
+            paragraph: {
+              rich_text: [{
+                type: 'text',
+                text: { content: 'Test content', link: null },
+                annotations: {
+                  bold: false,
+                  italic: false,
+                  strikethrough: false,
+                  underline: false,
+                  code: false,
+                  color: 'default'
+                },
+                plain_text: 'Test content',
+                href: null
+              }],
+              color: 'default'
+            }
           }
-        ]
-      };
+        ],
+        next_cursor: null,
+        has_more: false
+      } as ListBlockChildrenResponse;
 
       // @ts-expect-error accessing private instance for testing
-      exporter.notion.databases.query = async () => {
-        const error: any = new Error('Not found');
+      exporter.notion.databases.query = async (): Promise<never> => {
+        const error: NotionError = new Error('Not found');
         error.code = 'object_not_found';
         throw error;
       };
 
       // @ts-expect-error accessing private instance for testing
-      exporter.notion.pages.retrieve = async () => mockPageResponse;
+      exporter.notion.pages.retrieve = async (): Promise<PageObjectResponse> => mockPageResponse;
       // @ts-expect-error accessing private instance for testing
-      exporter.notion.blocks.children.list = async () => mockBlocksResponse;
+      exporter.notion.blocks.children.list = async (): Promise<ListBlockChildrenResponse> => mockBlocksResponse;
 
       const result = await exporter.exportRaw({ id: 'test-page-id', notionToken: 'fake-token' });
       const parsed = JSON.parse(result);
@@ -68,14 +165,14 @@ describe('NotionRawExporter', () => {
       });
     });
 
-    it('should throw error when neither database nor page is found', async () => {
+    it('should throw error when neither database nor page is found', async (): Promise<void> => {
       // @ts-expect-error accessing private instance for testing
-      exporter.notion.databases.query = async () => {
+      exporter.notion.databases.query = async (): Promise<never> => {
         throw new Error('Database not found');
       };
 
       // @ts-expect-error accessing private instance for testing
-      exporter.notion.pages.retrieve = async () => {
+      exporter.notion.pages.retrieve = async (): Promise<never> => {
         throw new Error('Page not found');
       };
 


### PR DESCRIPTION
- Exports MDX in a format that doesn't choke Nextra (curly quotes)
- Exports _meta.ts in the weight order of the Notion Pages 
- Add the ability to export JSON of the database along side the MDX
- Adds a few more subcommands for easier debugging of Notion API